### PR TITLE
rebuild for kernel 6.1.8, drop for now gcc kernel

### DIFF
--- a/nvidia.spec
+++ b/nvidia.spec
@@ -10,7 +10,8 @@
 %global kmod_o_dir		%{_libdir}/nvidia/%{_arch}/%{version}/
 
 %ifarch %{x86_64}
-%global kernels desktop server desktop-gcc server-gcc rc-desktop rc-server rc-desktop-gcc rc-server-gcc
+%global kernels desktop server rc-desktop rc-server
+# desktop-gcc server-gcc rc-desktop-gcc rc-server-gcc
 %else
 %global kernels desktop server rc-desktop rc-server
 %endif


### PR DESCRIPTION
gcc kernels was dropped due https://github.com/OpenMandrivaAssociation/kernel/commit/762f85498b01c32343be49e41736a08430f1e960 Revert is back when GCC kernels back